### PR TITLE
Revert "Fixed typo in search-engine-production prometheus job (#17)"

### DIFF
--- a/prometheus/custom_values.yaml
+++ b/prometheus/custom_values.yaml
@@ -836,7 +836,7 @@ serverFiles:
             regex: __meta_kubernetes_service_label_(.+)
           - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_namespace]
             action: keep
-            regex: search-engine;(production|staging)+
+            regex: search_engine;(production|staging)+
           - source_labels: [__meta_kubernetes_namespace]
             target_label: kubernetes_namespace
           - source_labels: [__meta_kubernetes_service_name]


### PR DESCRIPTION
This reverts commit ff1d877c206ee1fdd66135a66ce3835f206426ae.

##### Краткое описание

Изначальное значение search_engine было верным

откат сломанного коммита

##### Тип изменения

- Bugfix Pull Request

##### Название чарта

- prometheus

##### Дополнительная информация

<!--- Вывод команд вставлять здесь -->
```yaml
            regex: search_engine;(production|staging)+
```
